### PR TITLE
Add cleanup block to FastCache::Cache, with RSpec tests.

### DIFF
--- a/lib/fast_cache/cache.rb
+++ b/lib/fast_cache/cache.rb
@@ -32,14 +32,18 @@ module FastCache
     #                      the cache.
     # @param [Integer] expire_interval Number of cache operations between
     #                                  calls to {#expire!}.
-    def initialize(max_size, ttl, expire_interval = 100)
+    # @yield [Object] If a block is given, each time an object is removed
+    #                 from the cache, it will be yielded to the block. This
+    #                 is useful for cleaning up resources used by objects
+    #                 stored in the cache.
+    def initialize(max_size, ttl, expire_interval = 100, &cleanup)
       @max_size = max_size
       @ttl = ttl.to_f
       @expire_interval = expire_interval
       @op_count = 0
       @data = {}
       @expires_at = {}
-      @cleanup = Proc.new if block_given?
+      @cleanup = cleanup
     end
 
     # Retrieves a value from the cache, if available and not expired, or

--- a/lib/fast_cache/cache.rb
+++ b/lib/fast_cache/cache.rb
@@ -109,7 +109,7 @@ module FastCache
     #
     # @return [self]
     def clear
-      @data.values.map(&:value).map(&@cleanup) if @cleanup
+      @data.each_value {|entry| @cleanup.call(entry.value)} if @cleanup
       @data.clear
       @expires_at.clear
       self

--- a/spec/lib/fast_cache/cache_spec.rb
+++ b/spec/lib/fast_cache/cache_spec.rb
@@ -15,14 +15,19 @@ describe FastCache::Cache do
     end
   end
 
-  context 'non-empty cache' do
+  shared_context :non_empty_cache do
+    let(:cache) { described_class.new(3, 60, 1) }
     before do
-      @cache = described_class.new(3, 60, 1)
+      @cache = cache
       @cache[:a] = 1
       @cache[:b] = 2
       @cache[:c] = 3
     end
     subject { @cache }
+  end
+
+  context 'non-empty cache' do
+    include_context :non_empty_cache
 
     its(:empty?) { should be_false }
     its(:length) { should eq 3 }
@@ -110,6 +115,42 @@ describe FastCache::Cache do
         subject[:c].should be_nil
         subject[:d].should eq 4
         subject[:e].should eq 6
+      end
+    end
+
+    describe 'cleanup block' do
+      let(:cleanups) { [] }
+      let(:ttl) { 60 }
+      let(:cache) { described_class.new(3, ttl, 1) do |obj|
+        cleanups << obj
+      end }
+      it 'is called when the cache is cleared' do
+        subject.clear
+        cleanups.should =~ [1,2,3]
+      end
+      it 'is called when an item is deleted' do
+        subject.delete(:a).should eq 1
+        cleanups.should =~ [1]
+      end
+      it 'is called when an existing item is replaced' do
+        subject[:a] = 11
+        cleanups.should =~ [1]
+      end
+      it 'is called when an item is removed when full' do
+        subject[:d] = 4
+        cleanups.should =~ [1]
+      end
+
+      context 'with immediate expiration' do
+        let(:ttl) { 0 }
+        it 'is called when items are expired' do
+          subject.expire!
+          cleanups.should =~ [1,2,3]
+        end
+        it 'is called when item access triggers expiration' do
+          subject[:a].should be_nil
+          cleanups.should =~ [1,2,3]
+        end
       end
     end
   end


### PR DESCRIPTION
This allows the user to specify a block to be called whenever an object is removed from the cache, to perform some cleanup action on it:

Example usage scenario -- caching connections that should be closed upon removal from the cache:

``` ruby
  cache = FastCache::Cache.new do |conn|
    conn.close
  end

  cache.fetch('/some/connection') do
    Connection.new
  end
```
