### PR TITLE
fix rspec tests

### DIFF
--- a/fast_cache.gemspec
+++ b/fast_cache.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.0"
+  spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "yard"
-  spec.add_development_dependency "redcarpet"
 end

--- a/fast_cache.gemspec
+++ b/fast_cache.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 2.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "timecop"

--- a/spec/lib/fast_cache/cache_spec.rb
+++ b/spec/lib/fast_cache/cache_spec.rb
@@ -5,7 +5,7 @@ describe FastCache::Cache do
   context 'empty cache' do
     subject { described_class.new(5, 60, 1) }
 
-    its(:empty?) { should be_true }
+    its(:empty?) { should be_truthy }
     its(:length) { should eq 0 }
     its(:size) { should eq 0 }
     its(:count) { should eq 0 }
@@ -24,7 +24,7 @@ describe FastCache::Cache do
     end
     subject { @cache }
 
-    its(:empty?) { should be_false }
+    its(:empty?) { should be_falsey }
     its(:length) { should eq 3 }
     its(:size) { should eq 3 }
     its(:count) { should eq 3 }
@@ -136,7 +136,7 @@ describe FastCache::Cache do
         subject[:a].should be_nil
 
         subject.fetch(:a) do
-          true.should be_true
+          true.should be_truthy
           5
         end.should == 5
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec/its'
 require 'simplecov'
 SimpleCov.start
 SimpleCov.minimum_coverage 100


### PR DESCRIPTION
This tightens the required RSpec version in the gemspec, and fixes a couple of tests.
Additionally, it removes an unused gem that was causing compatibility issues with JRuby.
